### PR TITLE
Support implicit IP Address of client

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ yarn add iplocation
 
 ### Usage
 
-__iplocation(ip, [providers], [callback])__
+__iplocation([ip], [providers], [callback])__
 
 __Providers:__
 
@@ -36,6 +36,9 @@ https://domain-name.tld/?ip=*&format=json
 
 Basically wherever the API requires the IP address put a `*` and the module
 will replace it with the IP address entered as arguments.
+
+You can ommit the IP address parameter to return data for the ip address of the requesting client, (in a server environment this will be the server public IP address, in a browser this will be the clients public IP address).
+
 
 __Callback:__
 

--- a/index.js
+++ b/index.js
@@ -17,15 +17,13 @@ module.exports = function () {
     throw new TypeError('Too many arguments.')
   }
 
-  var ip = args[0]
-  var alternativeProviders = (args[1] && Array.isArray(args[1]))
+  var ip = typeof args[0] === 'string' && args.shift()
+  var alternativeProviders = Array.isArray(args[0]) && args.shift()
   var providers = defaultProviders.concat(alternativeProviders || [])
 
-  var callback = alternativeProviders
-    ? args[2]
-    : args[1]
+  var callback = typeof args[0] === 'function' && args.shift()
 
-  if (!ipRegex().test(ip)) {
+  if (ip && !ipRegex().test(ip)) {
     var invalidIpError = new Error('Invalid IP address.')
     return callback
       ? callback(invalidIpError, null)
@@ -38,7 +36,7 @@ module.exports = function () {
       return callback(providerError, null)
     }
 
-    var url = providers[i].replace('*', ip)
+    var url = providers[i].replace('*', ip || '')
 
     debug('trying: ' + url)
 

--- a/test/arguments.js
+++ b/test/arguments.js
@@ -40,3 +40,14 @@ describe('too many arguments', function () {
     }
   })
 })
+
+describe('implicit (no) ip address', function () {
+  it('return data about requesting client', function (done) {
+    ipLocation(function (err, res) {
+      assert(!err)
+      assert(typeof res === 'object')
+      assert(res.ip)
+      setTimeout(done, 1000)
+    })
+  })
+})


### PR DESCRIPTION
Often, if this is being used on the client we are wanting information about the current user. On the client we do not have access (within the browser) to the users IP address. The 3 default providers support passing no IP address, this will then return the location details for the current user.

By omitting the IP address parameter (or `True` if you wish to imply that true means use current users IP address) this will now return information about the current user.