### PR TITLE
Fix issue client side CORS issue with ipapi.co

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = function () {
 
     debug('trying: ' + url)
 
-    request.get(url, function (err, response, body) {
+    request.get(url, { withCredentials: false }, function (err, response, body) {
       var json
 
       try {


### PR DESCRIPTION
The following error is currently returned by the from `ipapi.co` when running on the client (in the browser). We can prevent this error by passing `withCredentials: false` in the options to the `request`.

```
The value of the 'Access-Control-Allow-Origin' header in the response must not be the wildcard '*' when the request's credentials mode is 'include'. Origin '[ORIGIN HERE]' is therefore not allowed access. The credentials mode of requests initiated by the XMLHttpRequest is controlled by the withCredentials attribute.
```