### PR TITLE
5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ __Callback:__
 
 If you omit the callback argument, the function will return a promise.
 
-__Default providers:__
+__Providers:__
 
-This module will try the following providers _in order_ if each request fails:
+This module will try providers _in order_, moving onto then next provider if the request fails. If provided, additional providers will be tried first, if the all additional providers fail or none are provided then the following defaults are tried _in order_.
 
 * https://freegeoip.net/
 * https://ipapi.co/
 
-You won't get anything if __all__ fail, but you can provide additional providers as well.
+You won't get anything if __all__ providers fail.
 
 __Callbacks:__
 

--- a/README.md
+++ b/README.md
@@ -48,9 +48,8 @@ __Default providers:__
 
 This module will try the following providers _in order_ if each request fails:
 
-* https://ipapi.co/
 * https://freegeoip.net/
-* http://ip-api.com/json/
+* https://ipapi.co/
 
 You won't get anything if __all__ fail, but you can provide additional providers as well.
 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = function () {
 
   var ip = typeof args[0] === 'string' && args.shift()
   var alternativeProviders = Array.isArray(args[0]) && args.shift()
-  var providers = defaultProviders.concat(alternativeProviders || [])
+  var providers = (alternativeProviders || []).concat(defaultProviders)
 
   var callback = typeof args[0] === 'function' && args.shift()
 

--- a/index.js
+++ b/index.js
@@ -6,8 +6,7 @@ var request = require('request')
 
 var defaultProviders = [
   'https://freegeoip.net/json/*',
-  'https://ipapi.co/*/json/',
-  'http://ip-api.com/json/*'
+  'https://ipapi.co/*/json/'
 ]
 
 module.exports = function () {

--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ var ipRegex = require('ip-regex')
 var request = require('request')
 
 var defaultProviders = [
-  'https://ipapi.co/*/json/',
   'https://freegeoip.net/json/*',
+  'https://ipapi.co/*/json/',
   'http://ip-api.com/json/*'
 ]
 


### PR DESCRIPTION
`v5.0` has the following changes:
* Re-ordered the default providers (`freegeoip` has a 15,000 per hour limit, compared with `ipapi` with a daily limit of 1000).
* Remove `ip-api` from list of default providers as they do not allow for commercial use.
* Use additional providers before falling back to default providers.

This is proposed as a major release due to the following possible breaking issue(s):
* As the response object for each provider can differ in shape this release may break implementations where developers have only catered for `ipapi`responses.