### PR TITLE
Custom `User-Agent` and a more informative error message

### DIFF
--- a/source/index.ts
+++ b/source/index.ts
@@ -29,6 +29,10 @@ interface IpApiData {
 }
 
 declare namespace ipLocation {
+	export interface Options {
+		userAgent?: string // The User-Agent header to send along. Useful if you receive unexpected 429 Rate Limited errors.
+	}
+
 	export interface LocationData {
 		latitude: number
 		longitude: number
@@ -73,18 +77,18 @@ declare namespace ipLocation {
 /**
 Get ip location information.
 @param ip The ipv4 address to get the information for.
-@param userAgent The User-Agent header to send along. Useful if you receive unexpected 429 Rate Limited errors.
+@param options An Options object. Optional.
 @example
 ```
 const ipLocation = require("iplocation");
 
 (async () => {
-	await ipLocation("172.217.167.78", "My Awesome Project (mailto:author@example.org)");
+	await ipLocation("172.217.167.78", { userAgent: "My Awesome Project (mailto:author@example.org)" });
 	//=> { latitude: -33.8591, longitude: 151.2002, region: { name: "New South Wales" ... } ... }
 })();
 ```
 */
-async function ipLocation(ip: string, userAgent: string): Promise<ipLocation.ReturnType> {
+async function ipLocation(ip: string, options: ipLocation.Options = {}): Promise<ipLocation.ReturnType> {
 	if (typeof ip !== "string" || !isIp.v4(ip)) {
 		throw new TypeError(`${typeof ip} '${ip}' is not a valid IPv4 address`)
 	}
@@ -116,7 +120,7 @@ async function ipLocation(ip: string, userAgent: string): Promise<ipLocation.Ret
 		`https://ipapi.co/${ip}/json/`,
 		{
 			headers: {
-				"User-Agent": userAgent
+				"User-Agent": options.userAgent
 			}
 		}
 	).json()

--- a/source/index.ts
+++ b/source/index.ts
@@ -86,7 +86,7 @@ const ipLocation = require("iplocation");
 */
 async function ipLocation(ip: string, userAgent: string): Promise<ipLocation.ReturnType> {
 	if (typeof ip !== "string" || !isIp.v4(ip)) {
-		throw new TypeError("A valid ipv4 address must be provided!")
+		throw new TypeError(`${typeof ip} '${ip}' is not a valid IPv4 address`)
 	}
 
 	const {

--- a/source/index.ts
+++ b/source/index.ts
@@ -73,22 +73,53 @@ declare namespace ipLocation {
 /**
 Get ip location information.
 @param ip The ipv4 address to get the information for.
+@param userAgent The User-Agent header to send along. Useful if you receive unexpected 429 Rate Limited errors.
 @example
 ```
 const ipLocation = require("ip-location");
 
 (async () => {
-	await ipLocation("172.217.167.78");
+	await ipLocation("172.217.167.78", "My Awesome Project (mailto:author@example.org)");
 	//=> { latitude: -33.8591, longitude: 151.2002, region: { name: "New South Wales" ... } ... }
 })();
 ```
 */
-async function ipLocation(ip: string): Promise<ipLocation.ReturnType> {
+async function ipLocation(ip: string, userAgent: string): Promise<ipLocation.ReturnType> {
 	if (typeof ip !== "string" || !isIp.v4(ip)) {
 		throw new TypeError("A valid ipv4 address must be provided!")
 	}
 
-	const { latitude, longitude, city, reserved, region, region_code, country_name, country_code, country_code_iso3, country_capital, country_tld, country_population, country_calling_code, continent_code, in_eu, postal, timezone, utc_offset, currency, currency_name, languages, country_area }: IpApiData = await ky(`https://ipapi.co/${ip}/json/`).json()
+	const {
+		latitude,
+		longitude,
+		city,
+		reserved,
+		region,
+		region_code,
+		country_name,
+		country_code,
+		country_code_iso3,
+		country_capital,
+		country_tld,
+		country_population,
+		country_calling_code,
+		continent_code,
+		in_eu,
+		postal,
+		timezone,
+		utc_offset,
+		currency,
+		currency_name,
+		languages,
+		country_area
+	}: IpApiData = await ky(
+		`https://ipapi.co/${ip}/json/`,
+		{
+			headers: {
+				"User-Agent": userAgent
+			}
+		}
+	).json()
 
 	return reserved ? {
 		reserved

--- a/source/index.ts
+++ b/source/index.ts
@@ -76,7 +76,7 @@ Get ip location information.
 @param userAgent The User-Agent header to send along. Useful if you receive unexpected 429 Rate Limited errors.
 @example
 ```
-const ipLocation = require("ip-location");
+const ipLocation = require("iplocation");
 
 (async () => {
 	await ipLocation("172.217.167.78", "My Awesome Project (mailto:author@example.org)");


### PR DESCRIPTION
Hey there! Thanks for taking care of this library.

This PR includes a couple of small tweaks.
1. *Ability to set a custom `User-Agent` header.* I noticed that the provider has started returning 429 Rate Limited a bit too often. It appears that `node-fetch` is the keyword triggering this behaviour. Fair enough! Having a custom `User-Agent` fixes this issue + it's just the nice thing to do. If you have a different preference for the parameter style, let me know.
2. *Including type and value of `ip` in the `TypeError` message.* These occasionally happen to me in production, and I hope the expanded error message can provide more insight.